### PR TITLE
Add null check to buying system

### DIFF
--- a/Assets/Scripts/BuyMenu/BuyingSystem.cs
+++ b/Assets/Scripts/BuyMenu/BuyingSystem.cs
@@ -23,8 +23,10 @@ public class BuyingSystem : MonoBehaviour
     void LateUpdate()
     {
         currentRound = GameManager.globalManager.timer.GetRound();
-        weaponCountEcho.text = "Weapon Buy Limit: " + (GetWeaponBuyLimit() - currentAdded);
-        materialCountEcho.text = "Material Buy Limit: " + (GetMaterialBuyLimit() - currentAdded);
+        if (weaponCountEcho)
+            weaponCountEcho.text = "Weapon Buy Limit: " + (GetWeaponBuyLimit() - currentAdded);
+        if (materialCountEcho)
+            materialCountEcho.text = "Material Buy Limit: " + (GetMaterialBuyLimit() - currentAdded);
     }
 
     public int GetCurrentRound()


### PR DESCRIPTION
+ Buying system is included in FinalResults scene, but required weapon and material text objects. Since there aren't any, unity errors during this process. So, add an if check